### PR TITLE
Wrap `JSON.parse` in `try/catch`

### DIFF
--- a/lib/meetup.js
+++ b/lib/meetup.js
@@ -364,7 +364,15 @@ class APIRequest {
                     let response = null;
 
                     if (!err) {
-                        response = (!Object.keys(res.body).length) ? JSON.parse(res.text) : res.body;
+                        let parsed;
+
+                        try {
+                          parsed = JSON.parse(res.text);
+                        } catch(error) {
+                          callback(error);
+                        }
+
+                        response = (!Object.keys(res.body).length) ? parsed : res.body;
                         if (res.header['x-ratelimit-limit']) {
                             response.ratelimit = {
                                 limit: res.header['x-ratelimit-limit'],


### PR DESCRIPTION
As mentioned in #23 we're encountering edge cases where the `JSON.parse` is throwing a `SyntaxError`. This wraps it in a `try/catch` and passes errors to `callback` for handling by the consumer.