### PR TITLE
Adding response to HTTP request error object

### DIFF
--- a/lib/meetup.js
+++ b/lib/meetup.js
@@ -370,6 +370,7 @@ class APIRequest {
                         } catch(error) {
 							response = null;
 							err = error;
+                            err.response = res;
                         }
 
                         if (res.header['x-ratelimit-limit']) {

--- a/lib/meetup.js
+++ b/lib/meetup.js
@@ -370,7 +370,7 @@ class APIRequest {
                         } catch(error) {
 							response = null;
 							err = error;
-                            err.response = res;
+							err.response = res;
                         }
 
                         if (res.header['x-ratelimit-limit']) {


### PR DESCRIPTION
@jkutianski This is a super simple tweak that I mentioned in #23. We continue to get random `Unexpected end of JSON input` errors from `getGroups` and having the response attached to the error object would help dissect issues more in-depth.