### PR TITLE
Replace deprecated endpoints relating to event CRUD.

### DIFF
--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -125,12 +125,12 @@
         }
     },
     "postEvent": {
-        "resource": "https://api.meetup.com/2/event",
+        "resource": "https://api.meetup.com/:group_urlname/events",
         "method": "post"
     },
     "editEvent": {
-        "resource": "https://api.meetup.com/2/event/:id",
-        "method": "post"
+        "resource": "https://api.meetup.com/:group_urlname/events/:id",
+        "method": "patch"
     },
     "deleteEvent": {
         "resource": "https://api.meetup.com/2/event/:id",

--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -133,7 +133,7 @@
         "method": "patch"
     },
     "deleteEvent": {
-        "resource": "https://api.meetup.com/2/event/:id",
+        "resource": "https://api.meetup.com/:group_urlname/events/:id",
         "method": "delete"
     },
     "getEventComments": {

--- a/lib/meetup.js
+++ b/lib/meetup.js
@@ -377,7 +377,7 @@ class APIRequest {
                     if (!err) {
 
                         try {
-                            response = (!Object.keys(res.body).length) ? JSON.parse(res.text) : res.body;
+                            response =  (res.statusCode === 204 ? '' :  ((!Object.keys(res.body).length) ? JSON.parse(res.text) : res.body));
                         } catch (error) {
                             response = null;
                             err = error;


### PR DESCRIPTION
Great work on this library.  A few of the endpoints it uses have now been deprecated by meetup; this PR replaces the ones we need to use with up-to-date endpoints.  It makes no attempt to validate the arguments provided to the API requests, so, for example, if you leave off the group_urlname node will insert 'undefined' and the API give a 404 status; I guess you probably know best how to solve that problem.